### PR TITLE
[BEBIG-187] feat : refresh-token  로그인 로그아웃 반영

### DIFF
--- a/src/main/java/beBig/controller/TokenController.java
+++ b/src/main/java/beBig/controller/TokenController.java
@@ -1,0 +1,61 @@
+package beBig.controller;
+
+
+import beBig.service.jwt.JwtTokenProvider;
+import beBig.service.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.Map;
+
+@CrossOrigin("*")
+@Controller
+@RequestMapping("/token")
+@Slf4j
+@RequiredArgsConstructor
+public class TokenController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @GetMapping()
+    public ResponseEntity<Map<String, Object>> refreshToken(
+            @RequestHeader("Authorization") String token, HttpServletRequest request) {
+
+        String refreshToken = request.getHeader("refreshToken");
+        Map<String, Object> response = new HashMap<>();
+
+        try {
+            // 1. Access Token이 유효한 경우
+            if (jwtTokenProvider.validateToken(token)) {
+                response.put("accessToken", token);
+                return ResponseEntity.ok(response);
+            }
+
+            // 2. Access Token이 유효하지 않고 Refresh Token만 유효한 경우 -> 새 Access Token 생성
+            if (jwtTokenProvider.checkRefreshToken(refreshToken)) {
+                String newAccessToken = jwtTokenProvider.refreshAccessToken(refreshToken);
+                response.put("accessToken", newAccessToken);
+                return ResponseEntity.ok(response);
+            }
+
+            // 3. 둘 다 유효하지 않은 경우
+            response.put("error", "Both tokens are invalid");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);  // 401 Unauthorized 상태 반환
+
+        } catch (Exception e) {
+            // 에러 발생 시, 로그 출력 및 500 Internal Server Error 반환
+            log.error("error: {}", e.getMessage());
+            response.put("error", "Internal Server Error");
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+        }
+    }
+}

--- a/src/main/java/beBig/controller/TokenController.java
+++ b/src/main/java/beBig/controller/TokenController.java
@@ -37,7 +37,7 @@ public class TokenController {
         try {
             // 1. Access Token이 유효한 경우
             if (jwtTokenProvider.validateToken(jwtToken)) {
-                response.put("accessToken", jwtToken);
+                response.put("accessTokenOK", jwtToken);
                 return ResponseEntity.ok(response);
             }
 

--- a/src/main/java/beBig/controller/TokenController.java
+++ b/src/main/java/beBig/controller/TokenController.java
@@ -30,13 +30,14 @@ public class TokenController {
     public ResponseEntity<Map<String, Object>> refreshToken(
             @RequestHeader("Authorization") String token, HttpServletRequest request) {
 
+        String jwtToken = token.replace("Bearer ", "");
         String refreshToken = request.getHeader("refreshToken");
         Map<String, Object> response = new HashMap<>();
 
         try {
             // 1. Access Token이 유효한 경우
-            if (jwtTokenProvider.validateToken(token)) {
-                response.put("accessToken", token);
+            if (jwtTokenProvider.validateToken(jwtToken)) {
+                response.put("accessToken", jwtToken);
                 return ResponseEntity.ok(response);
             }
 
@@ -44,6 +45,7 @@ public class TokenController {
             if (jwtTokenProvider.checkRefreshToken(refreshToken)) {
                 String newAccessToken = jwtTokenProvider.refreshAccessToken(refreshToken);
                 response.put("accessToken", newAccessToken);
+                log.info("accessToken 재발급 : {}", newAccessToken);
                 return ResponseEntity.ok(response);
             }
 

--- a/src/main/java/beBig/controller/UserController.java
+++ b/src/main/java/beBig/controller/UserController.java
@@ -140,15 +140,21 @@ public class UserController {
         request.getSession().invalidate();
 
         // JSESSIONID 쿠키 삭제
-        for (javax.servlet.http.Cookie cookie : request.getCookies()) {
-            if (cookie.getName().equals("JSESSIONID")) {
-                cookie.setMaxAge(0);
-                cookie.setPath("/");
-                response.addCookie(cookie);
+        javax.servlet.http.Cookie[] cookies = request.getCookies();
+        if (cookies != null) {  // 쿠키가 null인지 체크
+            for (javax.servlet.http.Cookie cookie : cookies) {
+                if (cookie.getName().equals("JSESSIONID")) {
+                    cookie.setMaxAge(0);  // 쿠키를 삭제
+                    cookie.setPath("/");
+                    response.addCookie(cookie);
+                }
             }
+        } else {
+            log.info("No cookies found in the request.");
         }
 
         String refreshToken = request.getHeader("refreshToken");
+        log.info("refreshToken: {}", refreshToken);
         userService.removeRefreshToken(refreshToken);
 
         return ResponseEntity.status(HttpStatus.OK).body("로그아웃에 성공하였습니다!");

--- a/src/main/java/beBig/mapper/UserMapper.java
+++ b/src/main/java/beBig/mapper/UserMapper.java
@@ -50,5 +50,10 @@ public interface UserMapper {
     FinTypeVo findFinTypeByUserId(long userId);
 
     List<UserVo> findBySameAgeRange(long userId);
+
     void clearRefreshTokenUser(@Param("refreshToken") String refreshToken);
+
+    Long findUserIdByUserLoginId(@Param("userLoginId") String userLoginId);
+
+    void clearRefreshTokenByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/beBig/mapper/UserMapper.java
+++ b/src/main/java/beBig/mapper/UserMapper.java
@@ -56,4 +56,6 @@ public interface UserMapper {
     Long findUserIdByUserLoginId(@Param("userLoginId") String userLoginId);
 
     void clearRefreshTokenByUserId(@Param("userId") Long userId);
+
+    int countRefreshTokenByUserId(Long userId);
 }

--- a/src/main/java/beBig/service/AssetServiceImp.java
+++ b/src/main/java/beBig/service/AssetServiceImp.java
@@ -133,13 +133,13 @@ public class AssetServiceImp implements AssetService {
         Map<String, Long> monthlySums = transactionVoList.stream()
                 .filter(t -> {
                     // String을 LocalDate로 변환하여 해당 연도에 맞는 거래만 필터링
-                    LocalDate date = LocalDate.parse(t.getTransactionDate(), formatter);
+                    LocalDate date = LocalDate.parse((CharSequence) t.getTransactionDate(), formatter);
                     return date.getYear() == year;
                 })
                 .collect(Collectors.groupingBy(
                         t -> {
                             // yyyy-MM 형식으로 월 추출
-                            LocalDate date = LocalDate.parse(t.getTransactionDate(), formatter);
+                            LocalDate date = LocalDate.parse((CharSequence) t.getTransactionDate(), formatter);
                             return date.format(DateTimeFormatter.ofPattern("yyyy-MM"));
                         },
                         Collectors.summingLong(TransactionVo::getTransactionAmount)

--- a/src/main/java/beBig/service/UserService.java
+++ b/src/main/java/beBig/service/UserService.java
@@ -24,4 +24,5 @@ public interface UserService {
 
     Long findUserIdByKakaoId(String kakaoId);
 
+    void removeRefreshToken(String refreshToken);
 }

--- a/src/main/java/beBig/service/UserService.java
+++ b/src/main/java/beBig/service/UserService.java
@@ -29,4 +29,7 @@ public interface UserService {
     Long findUserIdByUserLoginId(String userLoginId);
 
     void deleteRefreshTokenBeforeLogin(Long userId);
+
+    boolean checkIfRefreshTokenExistsByUserId(Long userId);
+
 }

--- a/src/main/java/beBig/service/UserService.java
+++ b/src/main/java/beBig/service/UserService.java
@@ -25,4 +25,8 @@ public interface UserService {
     Long findUserIdByKakaoId(String kakaoId);
 
     void removeRefreshToken(String refreshToken);
+
+    Long findUserIdByUserLoginId(String userLoginId);
+
+    void deleteRefreshTokenBeforeLogin(Long userId);
 }

--- a/src/main/java/beBig/service/UserServiceImp.java
+++ b/src/main/java/beBig/service/UserServiceImp.java
@@ -183,6 +183,14 @@ public class UserServiceImp implements UserService {
         return userMapper.getUserIdByKaKaoId(kakaoId);
     }
 
+    @Override
+    // db에서 refreshToken 지우기 (로그아웃시)
+    public void removeRefreshToken(String refreshToken) {
+        UserMapper userMapper = sqlSessionTemplate.getMapper(UserMapper.class);
+        userMapper.clearRefreshTokenRT(refreshToken);
+        userMapper.clearRefreshTokenUser(refreshToken);
+    }
+
 
     //    public UserVo findByUserId(String userId) throws Exception {
 //        return userMapper.findByUserId(userId);

--- a/src/main/java/beBig/service/UserServiceImp.java
+++ b/src/main/java/beBig/service/UserServiceImp.java
@@ -200,9 +200,15 @@ public class UserServiceImp implements UserService {
 
     @Override
     public void deleteRefreshTokenBeforeLogin(Long userId) {
-        userMapper.clearRefreshTokenByUserId(userId);
+        if (checkIfRefreshTokenExistsByUserId(userId)) {
+            userMapper.clearRefreshTokenByUserId(userId);
+        }
     }
 
+    @Override
+    public boolean checkIfRefreshTokenExistsByUserId(Long userId) {
+        return userMapper.countRefreshTokenByUserId(userId) > 0;
+    }
 
     //    public UserVo findByUserId(String userId) throws Exception {
 //        return userMapper.findByUserId(userId);

--- a/src/main/java/beBig/service/UserServiceImp.java
+++ b/src/main/java/beBig/service/UserServiceImp.java
@@ -25,11 +25,13 @@ public class UserServiceImp implements UserService {
 
     private final SqlSessionTemplate sqlSessionTemplate;
     private final PasswordEncoder passwordEncoder;
+    private final UserMapper userMapper;
 
     @Autowired
-    public UserServiceImp(SqlSessionTemplate sqlSessionTemplate, PasswordEncoder passwordEncoder) {
+    public UserServiceImp(SqlSessionTemplate sqlSessionTemplate, PasswordEncoder passwordEncoder, UserMapper userMapper) {
         this.sqlSessionTemplate = sqlSessionTemplate;
         this.passwordEncoder = passwordEncoder;
+        this.userMapper = userMapper;
     }
 
     // 유저 등록(회원가입)
@@ -189,6 +191,16 @@ public class UserServiceImp implements UserService {
         UserMapper userMapper = sqlSessionTemplate.getMapper(UserMapper.class);
         userMapper.clearRefreshTokenRT(refreshToken);
         userMapper.clearRefreshTokenUser(refreshToken);
+    }
+
+    @Override
+    public Long findUserIdByUserLoginId(String userLoginId) {
+        return userMapper.findUserIdByUserLoginId(userLoginId);
+    }
+
+    @Override
+    public void deleteRefreshTokenBeforeLogin(Long userId) {
+        userMapper.clearRefreshTokenByUserId(userId);
     }
 
 

--- a/src/main/java/beBig/service/jwt/JwtTokenProvider.java
+++ b/src/main/java/beBig/service/jwt/JwtTokenProvider.java
@@ -20,17 +20,13 @@ public class JwtTokenProvider {
 
     // io.jsonwebtoken.security.Keys를 통해 안전한 시크릿 키 생성
     private final SecretKey jwtSecret = Keys.secretKeyFor(SignatureAlgorithm.HS256); // 256비트 시크릿 키 생성
-    private final long jwtExpirationInMs = 1800000; // 토큰 유효시간 30분
-    private final long refreshTokenExpirationInMs = 604800000; // 7일 (1주일)
+    private final long jwtExpirationInMs = 1800000; // 토큰 유효시간 30분 = 1800000
+    private final long refreshTokenExpirationInMs = 604800000; // 7일 (1주일) 604800000
     private final UserMapper userMapper;
-//    private final JwtUtil jwtUtil;
-
     // JWT 토큰 생성
     public String generateToken(Long userId) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + jwtExpirationInMs);
-
-        generateRefreshToken(userId);
 
         return Jwts.builder()
                 .claim("userId", userId)   // userId를 클레임에 저장

--- a/src/main/java/beBig/service/jwt/JwtTokenProvider.java
+++ b/src/main/java/beBig/service/jwt/JwtTokenProvider.java
@@ -92,18 +92,6 @@ public class JwtTokenProvider {
         throw new JwtException("Invalid Refresh Token");
     }
 
-    // db에서 refreshToken 지우기 (로그아웃시)
-    public void removeRefreshToken(String refreshToken) {
-        userMapper.clearRefreshTokenRT(refreshToken);
-        userMapper.clearRefreshTokenUser(refreshToken);
-    }
-
-    //accessToken 검사
-    public long checkAccessToken(String token) {
-//        if (validateToken(token)) return jwtUtil.extractUserIdFromToken(token);
-        return -1;
-    }
-
     // refreshToken 검사
     public boolean checkRefreshToken(String refreshToken) {
         LocalDateTime expiryDate = userMapper.getExpiredTimeByRefreshToken(refreshToken);

--- a/src/main/java/beBig/service/oauth/KakaoOauthService.java
+++ b/src/main/java/beBig/service/oauth/KakaoOauthService.java
@@ -14,10 +14,10 @@ import java.net.URL;
 @Service
 public class KakaoOauthService {
 
-    // 카카오 REST API 키
+    // 카카오 REST API 키 <- 형이 바꿔야함
     private String REST_API_KEY = "f8156e1595fd76d2b241ad4b4f3c4ca6";
 
-    // 카카오 로그인 후 리다이렉트될 URI
+    // 카카오 로그인 후 리다이렉트될 URI <-이것도 형네주소
     private String REDIRECT_URI = "http://localhost:5173/user";
 
     public String getAccessToken(String authorize_code) {

--- a/src/main/resources/beBig/mapper/UserMapper.xml
+++ b/src/main/resources/beBig/mapper/UserMapper.xml
@@ -159,4 +159,16 @@
         SET refresh_token = null
         WHERE refresh_token = #{refreshToken};
     </update>
+
+    <delete id="clearRefreshTokenByUserId" parameterType="long">
+        delete
+        from refresh_token
+        where user_id = #{userId};
+    </delete>
+
+    <select id="findUserIdByUserLoginId" parameterType="String">
+        select user_id
+        from user
+        where user_login_id = #{userLoginId};
+    </select>
 </mapper>

--- a/src/main/resources/beBig/mapper/UserMapper.xml
+++ b/src/main/resources/beBig/mapper/UserMapper.xml
@@ -166,9 +166,16 @@
         where user_id = #{userId};
     </delete>
 
-    <select id="findUserIdByUserLoginId" parameterType="String">
+    <select id="findUserIdByUserLoginId" parameterType="String" resultType="long">
         select user_id
         from user
         where user_login_id = #{userLoginId};
     </select>
+
+    <select id="countRefreshTokenByUserId" parameterType="long" resultType="int">
+        select count(*)
+        from refresh_token
+        where user_id = #{userId}
+    </select>
+
 </mapper>


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 라벨 추가했나요?
-->
## Related Issue 🚀
<!--Jira에 있는 이슈 이름, 혹은 본인이 생각하는 이슈 적기 -->

### Jira Issue Link

<br>

## PR Summary ✏️
-  refresh-token  로그인 로그아웃 반영

변경사항
1. TokenController 추가
- 기존의 accessToken과 refreshToken을 같이 보내 유효한 accessToken을 발급해줌(기존이 유효할 경우 기존 유지)
- body에 "accessToken" : value 형식의 map 방식으로 리턴
- 두 토큰 모두 유효하지 않을시 body에 "error" : errorMsg 를 담아서 보냄 

2. UserController의 login 파트 수정
- return type Map<String,Object>로 수정
- token 변수명 access-token으로 변경 및 이제 accessToken과외에도 refreshToken도
반환되게끔 수정하였음

3. UserController의 logout파트수정
- 로그아웃시에 refreshToken user테이블에서 삭제하게하는 메서드 추가
- 대신 이전과는 달리 로그아웃시 request에 refresh-token 담아서 보내야함

4. UserController의 kakaoLogin, logout 파트수정
- 이제 로그인할시 refreshToken생성해서 db에 저장하고 프론트단에 같이보냄
- 이제 그로그아웃할시 refreshToken을 헤더에 담아서 보내야함, 로그아웃시 db에서 삭제하는 작업 추가

5. userService에 refreshToken삭제하는 기능 추가

## PR Descriptions
-  refresh-token  로그인 로그아웃 반영


<br>


###  스크린샷 (선택)



<br>

# Check
## Test Code Check
- [ ] repository 테스트 작성
- [ ] 메소드 테스트 작성
- [ ] 서비스 테스트 작성
- [ ] 테스트 못 한 메소드의 경우 //todo 로 표기
<br>

### Swagger Check
- [ ] 에러값 모두 작성
- [ ] 리턴값 모두 작성 

<br>

### Log Check
- [ ] 로그로 남길 부분이 있으며, 로그 표시를 완료 했나요?

<br>


## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->


<br>



close #
